### PR TITLE
bug: handle non player place_block in AntiBuild (resolves #241)

### DIFF
--- a/src/main/java/io/github/sakurawald/module/initializer/anti_build/AntiBuildInitializer.java
+++ b/src/main/java/io/github/sakurawald/module/initializer/anti_build/AntiBuildInitializer.java
@@ -9,6 +9,7 @@ import io.github.sakurawald.module.initializer.anti_build.config.model.AntiBuild
 import net.minecraft.entity.player.PlayerEntity;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -16,14 +17,18 @@ public class AntiBuildInitializer extends ModuleInitializer {
     public static final BaseConfigurationHandler<AntiBuildConfigModel> config = new ObjectConfigurationHandler<>(BaseConfigurationHandler.CONFIG_JSON, AntiBuildConfigModel.class);
 
     public static <T> void checkAntiBuild(PlayerEntity player, String antiType, Set<String> ids, String id, CallbackInfoReturnable<T> cir, T cancelWithValue, Supplier<Boolean> shouldSendFeedback) {
-        if ((ids.contains(id) || ids.contains("*"))
-            && !PermissionHelper.hasPermission(player.getUuid(), "fuji.anti_build.%s.bypass.%s".formatted(antiType, id))
-        ) {
+        if ((ids.contains(id) || ids.contains("*")) && !isAllowedByPlayerPermission(player, antiType, id)) {
             if (shouldSendFeedback.get()) {
                 TextHelper.sendMessageByKey(player, "anti_build.disallow");
             }
 
             cir.setReturnValue(cancelWithValue);
         }
+    }
+
+    private static boolean isAllowedByPlayerPermission(PlayerEntity player, String antiType, String id) {
+        return Optional.ofNullable(player)
+            .map(p -> PermissionHelper.hasPermission(player.getUuid(), "fuji.anti_build.%s.bypass.%s".formatted(antiType, id)))
+            .orElse(true);
     }
 }


### PR DESCRIPTION
`place_block` can be triggered by a dispenser and does not include a player in this case. I extended the check to handle the `null` case for the player parameter.