### PR TITLE
Optimized WorldGameRuleInitializer by replacing streams with for-loops

### DIFF
--- a/fabric/src/main/java/mod/fuji/module/initializer/world/gamerule/WorldGameRuleInitializer.java
+++ b/fabric/src/main/java/mod/fuji/module/initializer/world/gamerule/WorldGameRuleInitializer.java
@@ -47,20 +47,26 @@ public class WorldGameRuleInitializer extends ModuleInitializer {
     private static final BaseConfigurationHandler<WorldGameRuleConfigModel> config = ObjectConfigurationHandler.ofModule(BaseConfigurationHandler.CONFIG_JSON_LITERAL, WorldGameRuleConfigModel.class);
 
     public static Optional<GameRuleDescriptor> getEffectiveGameRuleDescriptor(String dimensionId) {
-        return config.model().gameRules
-            .stream()
-            .filter(it -> it.enable
-                && it.dimensionId.equals(dimensionId))
-            .findFirst();
+        var gameRules = config.model().gameRules;
+        for (GameRuleDescriptor gr : gameRules) {
+            if (gr.enable && gr.dimensionId.equals(dimensionId)) {
+                return Optional.of(gr);
+            }
+        }
+        return Optional.empty();
     }
 
+
     public static GameRules getEffectiveGameRules(String dimensionId, GameRules original) {
-        Optional<GameRuleDescriptor> effectiveGameRuleDescriptor = WorldGameRuleInitializer
-            .getEffectiveGameRuleDescriptor(dimensionId);
-        return effectiveGameRuleDescriptor
-            .map(GameRuleDescriptor::asVanillaGameRules)
-            .orElse(original);
+        var gameRules = config.model().gameRules;
+        for (GameRuleDescriptor gr : gameRules) {
+            if (gr.enable && gr.dimensionId.equals(dimensionId)) {
+                return gr.asVanillaGameRules();
+            }
+        }
+        return original;
     }
+
 
     @Override
     protected void registerGsonTypeAdapters() {

--- a/fabric/src/main/java/mod/fuji/module/initializer/world/gamerule/WorldGameRuleInitializer.java
+++ b/fabric/src/main/java/mod/fuji/module/initializer/world/gamerule/WorldGameRuleInitializer.java
@@ -1,19 +1,20 @@
 package mod.fuji.module.initializer.world.gamerule;
 
-import mod.fuji.core.config.mapper.GsonMapper;
+import it.unimi.dsi.fastutil.objects.Reference2BooleanMap;
+import it.unimi.dsi.fastutil.objects.Reference2IntMap;
 import mod.fuji.core.config.handler.abst.BaseConfigurationHandler;
 import mod.fuji.core.config.handler.impl.ObjectConfigurationHandler;
+import mod.fuji.core.config.mapper.GsonMapper;
 import mod.fuji.core.document.annotation.ColorBox;
 import mod.fuji.core.document.annotation.Document;
 import mod.fuji.module.initializer.ModuleInitializer;
-import mod.fuji.module.initializer.world.gamerule.config.model.WorldGameRuleConfigModel;
 import mod.fuji.module.initializer.world.gamerule.config.adapter.BooleanGameRuleMapAdapter;
-import mod.fuji.module.initializer.world.gamerule.structure.GameRuleDescriptor;
 import mod.fuji.module.initializer.world.gamerule.config.adapter.IntegerGameRuleMapAdapter;
-import it.unimi.dsi.fastutil.objects.Reference2BooleanMap;
-import it.unimi.dsi.fastutil.objects.Reference2IntMap;
-import java.util.Optional;
+import mod.fuji.module.initializer.world.gamerule.config.model.WorldGameRuleConfigModel;
+import mod.fuji.module.initializer.world.gamerule.structure.GameRuleDescriptor;
 import net.minecraft.world.GameRules;
+
+import java.util.Optional;
 
 @Document(id = 1752577892546L, value = """
     This module allows you to customize the `per-dimension gamerule`.
@@ -56,17 +57,11 @@ public class WorldGameRuleInitializer extends ModuleInitializer {
         return Optional.empty();
     }
 
-
     public static GameRules getEffectiveGameRules(String dimensionId, GameRules original) {
-        var gameRules = config.model().gameRules;
-        for (GameRuleDescriptor gr : gameRules) {
-            if (gr.enable && gr.dimensionId.equals(dimensionId)) {
-                return gr.asVanillaGameRules();
-            }
-        }
+        var gameRuleDescriptorOpt = getEffectiveGameRuleDescriptor(dimensionId);
+        if (gameRuleDescriptorOpt.isPresent()) return gameRuleDescriptorOpt.get().asVanillaGameRules();
         return original;
     }
-
 
     @Override
     protected void registerGsonTypeAdapters() {


### PR DESCRIPTION
- Replaced `stream().filter().findFirst()` with standard for-loops for memory and CPU efficiency.
- Removed unnecessary Optional creation in getEffectiveGameRules().
- Maintains same functionality while improving performance for per-dimension gamerule retrieval.